### PR TITLE
chore(launch server from vscode): launch the api from within VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ src/credentials.ts
 test-version.ts
 commands.txt
 package.json.test
+.env
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,19 @@
     // TODO there is one open issue with these configurations: the breakpoints added from VSCode go to the wrong line
     "configurations": [
         {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Dev Server",
+            "runtimeExecutable": "npm",
+            "cwd": "${workspaceFolder}",
+            "envFile": "${workspaceFolder}/.env",
+            "runtimeArgs": [
+                "run-script",
+                "dev-server:start"
+            ],
+            "port": 9229
+        },
+        {
             "name": "Dev server: attach",
             "type": "node",
             "request": "attach",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ The following is a set of guidelines, not rules, for contributing. Feel free to 
 
 -   [Database connection configuration](#database-connection-configuration)
 -   [Running the application locally in watch mode](#running-the-application-locally-in-watch-mode)
+-   [Running the application from VSCode](#running-the-application-from-vscode)
 -   [Manage application's container](#manage-applications-container)
 -   [Running the application from production-grade docker image](#running-the-application-from-production-grade-docker-image)
 -   [Import technologies from a Google Spreadsheet or csv file](#import-technologies-from-a-google-spreadsheet-or-csv-file)
@@ -297,6 +298,18 @@ Clean up the local application (this will also remove all your local application
 ```shell
 make dev_clean_up
 ```
+
+## Running the application from VSCode
+
+1. create a .env file in the root of the project where to define the required environment variables - in case of a local mongodb server this file could be
+    ```
+    MONGO_URI=mongodb://mylocalhosthost:27017/
+    MONGO_URI_ADMIN=mongodb://localhost:27017/
+    MONGO_DB_NAME=byorDev
+    ```
+1. go to the debug view of VSCode, select "Launch Dev Server" configuration and launch the debugger
+1. when on the Debug Console appears the message `-->[INFO] Listening on port 3000` the server is running
+1. you can now place breakpoints and debug interactively
 
 #### Debugging server from VSCode
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,6 @@ You can find more information about the BYOR-VotingApp in the web-app Github [re
     ```
 1. access the API on [http://localhost:3000](http://localhost:3000)
 
-## Launching API server from VSCode and running it locally
-
-1. clone the project as per above instructions
-1. provide a mongodb server and get its connnection string, e.g. "mongodb://localhost:27017/"
-1. create a .env file in the root of the project where to define the required environment variables - in case of a local mongodb server this file could be
-    ```
-    MONGO_URI=mongodb://mylocalhosthost:27017/
-    MONGO_URI_ADMIN=mongodb://localhost:27017/
-    MONGO_DB_NAME=byorDev
-    ```
-1. go to the debug view of VSCode, select "Launch Dev Server" configuration and launch the debugger
-1. when on the Debug Console appears the message `-->[INFO] Listening on port 3000` the server is running
-1. you can now place breakpoints and debug interactively
-
 > Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more options on running the server locally and connect to a MongoDB database.
 
 ## Running BYOR-VotingApp on Kubernetes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ You can find more information about the BYOR-VotingApp in the web-app Github [re
     ```
 1. access the API on [http://localhost:3000](http://localhost:3000)
 
+## Launching API server from VSCode and running it locally
+
+1. clone the project as per above instructions
+1. provide a mongodb server and get its connnection string, e.g. "mongodb://localhost:27017/"
+1. create a .env file in the root of the project where to define the required environment variables - in case of a local mongodb server this file could be
+    ```
+    MONGO_URI=mongodb://mylocalhosthost:27017/
+    MONGO_URI_ADMIN=mongodb://localhost:27017/
+    MONGO_DB_NAME=byorDev
+    ```
+1. go to the debug view of VSCode, select "Launch Dev Server" configuration and launch the debugger
+1. when on the Debug Console appears the message `-->[INFO] Listening on port 3000` the server is running
+1. you can now place breakpoints and debug interactively
+
 > Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for more options on running the server locally and connect to a MongoDB database.
 
 ## Running BYOR-VotingApp on Kubernetes


### PR DESCRIPTION

It is possible to launch the api server from within VSCode and leverage VSCode interactive debugging
facilities of VSCode as documented in the readme.md file

Thank you for your contribution to the byor-voting-server repo.
Before submitting this PR, please make sure:

-   [ ] Your code builds clean without any errors or warnings
-   [ ] You are using approved terminology
-   [ ] You have added unit tests
